### PR TITLE
APP-5979 : use local css names

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "node": ">=10"
   },
   "scripts": {
-    "build": "microbundle-crl --no-compress --format modern,cjs",
-    "start": "microbundle-crl watch --no-compress --format modern,cjs",
+    "build": "microbundle-crl --css-modules \"[local]\" --no-compress --format modern,cjs",
+    "start": "microbundle-crl watch --css-modules \"[local]\" --no-compress --format modern,cjs",
     "prepare": "run-s build",
     "test": "run-s test:unit test:lint test:build",
     "test:build": "run-s build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-tier-menu",
-  "version": "1.0.13",
+  "version": "1.0.15",
   "description": "A multi-tier select menu component",
   "author": "avigold",
   "license": "MIT",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,7 +22,7 @@ interface MenuProps extends Component {
     callback?: (item: MenuItem) => any;
     menuItems: MenuItem[];
     selection?: MenuItem;
-    placeholder?: string
+    placeholder?: string;
     bland?: boolean;
 }
 
@@ -88,8 +88,8 @@ export class MultiTierMenu extends Component<any, MenuState> {
             return null;
         }
 
-        let layoutItems: JSX.Element[] = [];
-        let secondLayoutItems: JSX.Element[] = [];
+        const layoutItems: JSX.Element[] = [];
+        const secondLayoutItems: JSX.Element[] = [];
         for (const menuItem of this.props.menuItems) {
             const rightArrow: JSX.Element | null = menuItem.children ?
                 <i className={`${styles.arrow} ${styles.arrowRight} ${styles.itemIcon}`}/> : null;
@@ -206,8 +206,6 @@ export class MultiTierMenu extends Component<any, MenuState> {
             const $target: JQuery = $(event.target).first();
             if (!$target.hasClass(containerClass) && !$target.parents(`.${containerClass}`).length) {
                 this.setState({ mainMenu: false, secondaryMenu: undefined, hoverPosition: undefined });
-            } else {
-                return;
             }
         });
     }


### PR DESCRIPTION
No longer generate CSS name hashes on CSS module compilation, instead using local names.